### PR TITLE
use null instead of [] as err argument if there are no errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function lookup(addrs, opts, fn) {
     errors = filter(errors);
     results = dedupe(filter(results));
     debug('errors=%j results=%j', errors, results);
-    fn(errors, results)
+    fn(errors.length ? errors : null, results);
   });
 }
 


### PR DESCRIPTION
If no errors are returned, the callback is called with an empty array, so users of this library can't use `if (err) { ... } else { ... }` to handle errors, because `[]` is truthy.

With this change, the callback is called with `null` as the first argument if there were no errors.
