### PR TITLE
Update superagent@3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "batch": "~0.5.0",
     "debug": "^2.2.0",
-    "superagent": "~3.5.0",
+    "superagent": "~3.8.3",
     "superagent-retry": "^0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Versions of `superagent` below 3.7.0 have a vulnerability documented in [CVE-2017-16129](https://nvd.nist.gov/vuln/detail/CVE-2017-16129). Update to a version where that vulnerability is already fixed.